### PR TITLE
Allow to set a custom prometheus registry

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -157,7 +157,12 @@ func (p *Prometheus) registerMetrics() {
 		},
 	)
 
-	p.registry.MustRegister(p.reqCnt, p.reqDur, p.reqSize, p.respSize)
+	if p.registry != nil {
+		p.registry.MustRegister(p.reqCnt, p.reqDur, p.reqSize, p.respSize)
+	} else {
+		prometheus.MustRegister(p.reqCnt, p.reqDur, p.reqSize, p.respSize)
+	}
+
 }
 
 func acquireRequestFromPool() *fasthttp.Request {


### PR DESCRIPTION
Added the ability to pass a custom prometheus registry. The default prometheus registry is used when no registry is specified